### PR TITLE
fix(prep): use imdbinfo cover_url/plot instead of non-existent poster_image/plot_outline

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -4116,31 +4116,17 @@ class Prep():
                 imdb_info['type'] = movie.kind
                 imdb_info['imdbID'] = movie.imdb_id
                 imdb_info['runtime'] = str(movie.duration // 60) if movie.duration else '0'
-                imdb_info['cover'] = movie.poster_image or meta.get('poster', '')
-                imdb_info['plot'] = movie.plot_outline or movie.plot or ''
+                imdb_info['cover'] = movie.cover_url or meta.get('poster', '')
+                imdb_info['plot'] = movie.plot or ''
                 imdb_info['genres'] = ', '.join([g for g in movie.genres]) if movie.genres else ''
                 imdb_info['rating'] = str(movie.rating) if movie.rating else 'N/A'
-                imdb_info['original_language'] = None
-                
-                # Try to get original language - handle different structures
-                if hasattr(movie, 'original_language'):
-                    orig_lang = movie.original_language
-                    if isinstance(orig_lang, list):
-                        imdb_info['original_language'] = orig_lang[0] if len(orig_lang) >= 1 else None
-                    elif isinstance(orig_lang, str):
-                        imdb_info['original_language'] = orig_lang
-                    else:
-                        imdb_info['original_language'] = None
-                
-                # Try to get directors - handle different structures
-                if hasattr(movie, 'principal_credits'):
-                    imdb_info['directors'] = []
-                    for credit in movie.principal_credits:
-                        if hasattr(credit, 'category') and credit.category == 'director':
-                            if hasattr(credit, 'credits') and isinstance(credit.credits, list):
-                                for person in credit.credits:
-                                    if hasattr(person, 'name'):
-                                        imdb_info['directors'].append(person.name)
+                # imdbinfo exposes languages as ISO codes (e.g. ['en', 'ko']); the first is the primary one
+                imdb_info['original_language'] = movie.languages[0] if movie.languages else None
+                imdb_info['directors'] = [p.name for p in (movie.directors or []) if getattr(p, 'name', None)]
+                if not imdb_info['directors']:
+                    # IMDb credits most series to creators rather than directors
+                    series_info = getattr(movie, 'info_series', None)
+                    imdb_info['directors'] = [p.name for p in (getattr(series_info, 'creators', None) or []) if getattr(p, 'name', None)]
                                 
             except Exception as e:
                 console.print(f"[yellow]IMDB: Error fetching data for IMDB ID {imdbID}: {str(e)}[/yellow]")


### PR DESCRIPTION
### What's broken

`Prep.get_imdb_info()` reads `movie.poster_image` and `movie.plot_outline`. Neither is a field on `imdbinfo`'s `MovieDetail` or `TvSeriesDetail`, so the first access raises `AttributeError`.

### Impact

The surrounding `try/except` catches it and only prints a warning, which makes it look cosmetic:

```
IMDB: Error fetching data for IMDB ID 1305826: 'TvSeriesDetail' object has no attribute 'poster_image'
```

It isn't. The exception aborts the block partway through, so every assignment after it is skipped:

| Populated | Never populated |
|---|---|
| `title`, `year`, `aka`, `type`, `imdbID`, `runtime` | `cover`, `plot`, `genres`, `rating`, `directors` |

Downstream, the poster, overview and IMDb rating silently come up empty on every upload. On the IMDb-only path (no TMDB id) it's worse: `imdb_other_meta()` indexes `imdb_info['cover']` directly and raises `KeyError`.

`requirements.txt` leaves `imdbinfo` unpinned, so a fresh install always pulls a release with this behaviour.

### Fix

Use the fields that actually exist: `cover_url` and `plot`.

This also removes two `hasattr()` branches that could never match:

- **`original_language`** isn't a field. `languages` is, holding ISO codes (`['en', 'ko']`).
- **`principal_credits`** isn't a field either. It corresponds to IMDb's `principalCreditsV2` block, which `imdbinfo` doesn't expose whole — it splits it into `stars`, and (for series) `info_series.creators`. `directors` is exposed separately, sourced from `crewV2`.

  The old block filtered `principal_credits` down to `category == 'director'` and discarded the rest, so its only output was director names. `movie.directors` applies the same `"director"` grouping filter, and therefore reproduces exactly what that block was trying to produce.

  Note `imdb_info['directors']` was consequently *never set at all*, despite three call sites indexing it directly.

- IMDb credits most series to **Creators** rather than Directors, so `directors` is legitimately empty for them. Where that happens we fall back to `info_series.creators`, which keeps `imdb_info['directors']` populated for TV uploads. `MovieDetail` has no `info_series`, so the fallback can never fire on films.

### Evidence

`poster_image` and `plot_outline` appear in **no published `imdbinfo` release** — I unpacked all 36 (0.2.5 → 0.9.1) and grepped every `.py`: zero hits. `cover_url` is present in all 36. So this isn't a version-pinning problem.

### Testing

Verified against both model classes, since they're distinct:

| | `cover` / `plot` / `genres` / `rating` | `original_language` | `directors` |
|---|---|---|---|
| movie `tt0071577` | populated | `en` | `['Jack Clayton']` |
| series `tt1305826` | populated | `en` | `['Pendleton Ward']` (via creators) |

Before the patch both raise `AttributeError`, print the warning above, and drop four keys. After, both return the full dict with nothing printed. `flake8` introduces no new warnings.

### Possible follow-up (deliberately not in this PR)

The broad `except Exception` that only prints a warning is what let this go unnoticed. Narrowing it, or re-raising, would surface this class of bug immediately.
