### PR TITLE
Pin guessit to 4.1.0 or newer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torf
-guessit
+guessit>=4.1.0
 ffmpeg-python
 pymediainfo==6.0.1
 tmdbsimple


### PR DESCRIPTION
Relates to #6.

`requirements.txt` did not constrain `guessit`, so an existing install can stay on 3.8.0. On that version the `episode_title` is dropped whenever a release tag such as `REPACK`, `PROPER` or `INTERNAL` sits between the episode marker and the title:

```
Some.Show.S02E05.REPACK.The.Title.Here.1080p.WEB-DL.x264-GRP.mkv
  -> episode_title missing
```

This was fixed upstream in guessit-io/guessit#842 (reported as guessit-io/guessit#775) and first released in guessit 4.0.0.

The floor is 4.1.0 rather than 4.0.0 because 4.0.2 and 4.1.0 also fix `title` parsing bugs, and `title` is the field `prep.py` reads most.

## Compatibility

- guessit 4.x needs Python >=3.10. The project already requires 3.12 (README, Dockerfile).
- guessit 4 bumps rebulk to 6.x. Nothing here imports rebulk directly.
- The full `requirements.txt` still resolves with no dependency conflicts.

## Testing

Ran a corpus of movie, episode and anime release names through guessit 3.8.0 and 4.1.0, comparing every field `prep.py` reads: `title`, `year`, `season`, `episode`, `episode_title`, `source`, `other`, `edition`, `screen_size`, `streaming_service`, `date` and `type`.

The only differences were the restored `episode_title` values. No regressions, and the varied input shapes `prep.py` passes to guessit (file names, directory paths, BDInfo titles and labels) parse identically on both versions.