### PR TITLE
Fix --manual_frames being parsed one character at a time

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -102,17 +102,6 @@ class Args():
         args, before_args = parser.parse_known_args(input)
         args = vars(args)
         # console.print(args)
-        if meta.get('manual_frames') is not None:
-            try:
-                # Join the list into a single string, split by commas, and convert to integers
-                meta['manual_frames'] = [int(time.strip()) for time in meta['manual_frames'].split(',')]
-                # console.print(f"Processed manual_frames: {meta['manual_frames']}")
-            except ValueError:
-                console.print("[red]Invalid format for manual_frames. Please provide a comma-separated list of integers.")
-                console.print(f"Processed manual_frames: {meta['manual_frames']}")
-                sys.exit(1)
-        else:
-            meta['manual_frames'] = None  # Explicitly set it to None if not provided
         if len(before_args) >= 1 and not os.path.exists(' '.join(args['path'])):
             for each in before_args:
                 args['path'].append(each)
@@ -248,6 +237,19 @@ class Args():
                 meta[key] = value
             # if key == 'help' and value == True:
                 # parser.print_help()
+
+        # Must run after the loop above, which copies the raw string from args into meta
+        manual_frames = meta.get('manual_frames')
+        if isinstance(manual_frames, str):
+            try:
+                meta['manual_frames'] = [int(frame) for frame in manual_frames.split(',') if frame.strip()] or None
+            except ValueError:
+                console.print("[red]Invalid format for manual_frames. Please provide a comma-separated list of integers.")
+                console.print(f"[red]Got: {manual_frames}")
+                sys.exit(1)
+        elif not manual_frames:
+            meta['manual_frames'] = None
+
         return meta, parser, before_args
 
     def list_to_string(self, list):

--- a/src/prep.py
+++ b/src/prep.py
@@ -1633,15 +1633,9 @@ class Prep():
         loglevel = 'verbose' if meta.get('ffdebug', False) else 'quiet'
         os.chdir(f"{base_dir}/tmp/{folder_id}")
 
-        if manual_frames:
-            manual_frames = [int(frame) for frame in manual_frames]
-            ss_times = [frame / frame_rate for frame in manual_frames]
-
-            if len(ss_times) < num_screens:
-                random_times = self.valid_ss_time(ss_times, num_screens - len(ss_times), length)
-                ss_times.extend(random_times)
-        else:
-            ss_times = self.valid_ss_time([], num_screens + 1, length)
+        # The capture loop below reads num_screens + 1 times
+        ss_times = [int(frame) / frame_rate for frame in manual_frames] if manual_frames else []
+        ss_times = self.valid_ss_time(ss_times, num_screens + 1, length)
 
         capture_tasks = []
         capture_results = []


### PR DESCRIPTION
Fixes #25.

`--manual_frames 40175` currently produces frames `[4, 0, 1, 7, 5]`. Two separate bugs cause this.

### 1. The value was never parsed (`src/args.py`)

The code that splits the comma-separated string into integers ran *before* the parsed arguments were merged into `meta`. It only ever saw a stale value, and reset `manual_frames` to `None`. The raw string was copied into `meta` immediately afterwards, so `screenshots()` received a string and iterated over it character by character.

Moving the conversion after the merge loop makes it operate on the value the user actually passed. `-mf 40175`, `--manual_frames=40175` and `-mf 100,200,300` all work now, and a non-numeric value exits with the existing error message rather than silently producing nonsense frames.

### 2. The manual-frames branch built one timestamp too few (`src/prep.py`)

The capture loop reads `num_screens + 1` timestamps, but that branch only built `num_screens`:

- With fewer manual frames than screenshots, the top-up call was handed the very list it was extending, so every timestamp ended up duplicated.
- With exactly `num_screens` frames, it raised `IndexError`.

Both branches now build `num_screens + 1` timestamps through a single `valid_ss_time()` call, which keeps the frames the user asked for and fills the rest at random.

### Testing

The repo has no test suite, so I exercised the changed code directly:

- `Args.parse` with `-mf 40175`, `--manual_frames=40175`, `--manual_frames 40175`, `-mf 100,200,300`, surrounding whitespace, the flag omitted, and a non-numeric value.
- The timestamp logic with no manual frames, one frame, three frames, exactly `num_screens` frames, and more frames than needed — checking the count, that the user's frames survive, and that nothing is duplicated.
