### PR TITLE
Drop pyrobase dependency to fix install on Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ anitopy
 cli-ui
 qbittorrent-api
 deluge-client
-pyrobase
 requests
 cinemagoer
 imdbinfo

--- a/src/clients.py
+++ b/src/clients.py
@@ -6,7 +6,6 @@ import os
 import qbittorrentapi
 from deluge_client import DelugeRPCClient
 import base64
-from pyrobase.parts import Bunch
 import errno
 import asyncio
 import ssl
@@ -433,7 +432,7 @@ class Clients():
         if single:
             if os.path.isdir(datapath):
                 datapath = os.path.join(datapath, metainfo["info"]["name"])
-            files = [Bunch(
+            files = [dict(
                 path=[os.path.abspath(datapath)],
                 length=metainfo["info"]["length"],
             )]


### PR DESCRIPTION
`pyrobase` fails to build on Python 3.13 (`ModuleNotFoundError: No module named 'pkg_resources'`), so the tool cannot be installed there at all. It is unmaintained, with no release since 2020.

It was used for exactly one thing: `from pyrobase.parts import Bunch`, for a single `Bunch(path=..., length=...)` call in `add_fast_resume`.

`pyrobase.parts.Bunch` is a `dict` subclass that adds attribute access. The attribute half was never used here — the surrounding loop reads `fileinfo["path"]` and `fileinfo["length"]` by subscript, and has to work for the multi-file branch too, where the entries are plain bencoded dicts. So a plain `dict` is a drop-in replacement.

Verified `pip install -r requirements.txt` now succeeds on Python 3.13, and that `add_fast_resume` produces byte-identical resume data before and after, across the single-file, directory-datapath, multi-file, and size-mismatch error paths.