### PR TITLE
Only query TVmaze for TV releases; stop false-positive show matches on movies

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -679,8 +679,11 @@ class Prep():
             meta = await self.imdb_other_meta(meta)
         else:
             meta = await self.tmdb_other_meta(meta)
-        # Search tvmaze
-        meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await self.search_tvmaze(filename, meta['search_year'], meta.get('imdb_id', '0'), meta.get('tvdb_id', 0), meta)
+        # Search tvmaze (TVmaze indexes TV only, so a movie can only ever get a false match)
+        if meta['category'] == "TV":
+            meta['tvmaze_id'], meta['imdb_id'], meta['tvdb_id'] = await self.search_tvmaze(filename, meta['search_year'], meta.get('imdb_id', '0'), meta.get('tvdb_id', 0), meta)
+        else:
+            meta['tvmaze_id'] = 0
         # If no imdb, search for it
         if meta.get('imdb_id', None) is None:
             meta['imdb_id'] = await self.search_imdb(filename, meta['search_year'])

--- a/src/prep.py
+++ b/src/prep.py
@@ -4201,16 +4201,19 @@ class Prep():
             tvdb_resp = self._make_tvmaze_request("https://api.tvmaze.com/lookup/shows", {"thetvdb": tvdbID}, meta)
             if tvdb_resp:
                 results.append(tvdb_resp)
-        if int(imdbID) != 0:
+        if not results and int(imdbID) != 0:
             imdb_resp = self._make_tvmaze_request("https://api.tvmaze.com/lookup/shows", {"imdb": f"tt{imdbID}"}, meta)
             if imdb_resp:
                 results.append(imdb_resp)
-        search_resp = self._make_tvmaze_request("https://api.tvmaze.com/search/shows", {"q": filename}, meta)
-        if search_resp:
-            if isinstance(search_resp, list):
-                results.extend([each['show'] for each in search_resp if 'show' in each])
-            else:
-                results.append(search_resp)
+        # Fuzzy title search is a last resort: results[0] is auto-selected with no
+        # confidence scoring, so never let it compete with an authoritative ID match.
+        if not results:
+            search_resp = self._make_tvmaze_request("https://api.tvmaze.com/search/shows", {"q": filename}, meta)
+            if search_resp:
+                if isinstance(search_resp, list):
+                    results.extend([each['show'] for each in search_resp if 'show' in each])
+                else:
+                    results.append(search_resp)
 
         if year not in (None, ''):
             results = [show for show in results if str(show.get('premiered', '')).startswith(str(year))]

--- a/src/prep.py
+++ b/src/prep.py
@@ -4278,6 +4278,11 @@ class Prep():
             resp = requests.get(url, params=params)
             if resp.ok:
                 return resp.json()
+            elif resp.status_code == 404:
+                # TVmaze documents 404 as "no match" for lookups, not a failure
+                if meta['debug']:
+                    print(f"No TVmaze match for {url} with params: {params}")
+                return None
             else:
                 print(f"HTTP Request failed with status code: {resp.status_code}, response: {resp.text}")
                 return None

--- a/src/prep.py
+++ b/src/prep.py
@@ -3945,11 +3945,11 @@ class Prep():
             generic.write(f"{res} / {meta['type']}{tag}\n\n")
             generic.write(f"Category: {meta['category']}\n")
             generic.write(f"TMDB: https://www.themoviedb.org/{meta['category'].lower()}/{meta['tmdb']}\n")
-            if meta['imdb_id'] != "0":
+            if int(meta['imdb_id']) != 0:
                 generic.write(f"IMDb: https://www.imdb.com/title/tt{meta['imdb_id']}\n")
-            if meta['tvdb_id'] != "0":
+            if int(meta['tvdb_id']) != 0:
                 generic.write(f"TVDB: https://www.thetvdb.com/?id={meta['tvdb_id']}&tab=series\n")
-            if meta['tvmaze_id'] != "0":
+            if int(meta['tvmaze_id']) != 0:
                 generic.write(f"TVMaze: https://www.tvmaze.com/shows/{meta['tvmaze_id']}\n")
             poster_img = f"{meta['base_dir']}/tmp/{meta['uuid']}/POSTER.png"
             if meta.get('poster', None) not in ['', None] and not os.path.exists(poster_img):


### PR DESCRIPTION
## The problem

Uploading a movie (IMDb `tt2516806`, a 1990 film) printed this mid-run:

```
HTTP Request failed with status code: 404, response: null
```

and then attached a completely unrelated TV show to the release:

```
TVMaze: https://www.tvmaze.com/shows/55163
```

TVmaze 55163 is a TV sitcom that happens to share a word with the movie's title and premiered the same year.

## Why it happens

`search_tvmaze()` is called for every release regardless of category, but TVmaze only indexes TV. For a movie that means:

1. `lookup/shows?imdb=tt2516806` 404s (the ID simply isn't in a TV database), and the 404 gets printed as if it were a failure.
2. The code then runs a fuzzy `search/shows?q=<title>` anyway, and any hit that matches on year is auto-selected as `results[0]` with no confidence scoring — so a same-year title collision wins.

## What's in here

Four commits, reviewable independently:

1. **Only query TVmaze for TV releases** — movies skip the call entirely and get `tvmaze_id = 0`.
2. **Fall back to the title search only when the ID lookups find nothing** — the authoritative TVDB/IMDb lookups now short-circuit the fuzzy search instead of pooling results with it.
3. **Stop printing TVmaze 404s as request failures** — 404 is TVmaze's documented "no match" for lookups; it's now silent unless `--debug`.
4. **Fix the `GENERIC_INFO.txt` ID guards** — `tvdb_id`/`tvmaze_id` are ints, so `!= "0"` was always true and the file got `.../shows/0` and `?id=0` links whenever there was no match.

Fixes 1–3 mirror what [Audionut/Upload-Assistant](https://github.com/Audionut/Upload-Assistant/blob/master/src/tvmaze.py) already does; this keeps the changes in place in `prep.py` rather than porting their `TvmazeManager` refactor.

## Verified

Against the live TVmaze API:

- Movie: zero calls to `api.tvmaze.com`, no 404 line, `tvmaze_id == 0`.
- TV with a TVDB id, and TV with only an IMDb id: both still resolve correctly, and now without firing the fuzzy title search.
- TV with no IDs: still falls back to the title search and resolves.
- `--tvmaze <id>` and the `manual_date` picker both still work.
- Every consumer of `tvmaze_id` (`upload.py`, `MTV`, `NBL`, `TVC`, `BHDTV`) already guards on `!= 0`, so the movie path is safe.

On the pre-fix commit the same inputs reproduce the bug exactly: `tvmaze_id -> 55163` plus the 404 line.

## Note for anyone hitting this

The bad ID is cached — affected releases have `tvmaze_id` written into `tmp/<release>/meta.json` and will keep reusing it until that file is cleared.
