### PR TITLE
Use plain '#' fill for tqdm progress bars

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1279,7 +1279,7 @@ class Prep():
                             pool.imap_unordered(self.capture_disc_task, capture_tasks),
                             total=len(capture_tasks),
                             desc="Capturing Screenshots",
-                            ascii=True,
+                            ascii=" #",
                             dynamic_ncols=False
                         )
                     )
@@ -1303,7 +1303,7 @@ class Prep():
                             pool.imap_unordered(self.optimize_image_task, optimize_tasks),
                             total=len(optimize_tasks),
                             desc="Optimizing Images",
-                            ascii=True,
+                            ascii=" #",
                             dynamic_ncols=False
                         )
                     )
@@ -1456,7 +1456,7 @@ class Prep():
 
         with get_context("spawn").Pool(processes=min(num_screens + 1, task_limit)) as pool:
             try:
-                results = list(tqdm(pool.imap_unordered(self.capture_dvd_screenshot, tasks), total=len(tasks), desc="Capturing Screenshots", ascii=True, dynamic_ncols=False))
+                results = list(tqdm(pool.imap_unordered(self.capture_dvd_screenshot, tasks), total=len(tasks), desc="Capturing Screenshots", ascii=" #", dynamic_ncols=False))
             finally:
                 pool.close()
                 pool.join()
@@ -1489,7 +1489,7 @@ class Prep():
                         pool.imap_unordered(self.optimize_image_task, optimize_tasks),
                         total=len(optimize_tasks),
                         desc="Optimizing Images",
-                        ascii=True,
+                        ascii=" #",
                         dynamic_ncols=False
                     )
                 )
@@ -1661,7 +1661,7 @@ class Prep():
                 console.print("[yellow]All screenshots already exist. Skipping capture process.")
             else:
                 if use_tqdm():
-                    with tqdm(total=len(capture_tasks), desc="Capturing Screenshots", ascii=True, dynamic_ncols=False) as pbar:
+                    with tqdm(total=len(capture_tasks), desc="Capturing Screenshots", ascii=" #", dynamic_ncols=False) as pbar:
                         with get_context("spawn").Pool(processes=min(len(capture_tasks), task_limit)) as pool:
                             try:
                                 for result in pool.imap_unordered(self.capture_screenshot, capture_tasks):
@@ -1692,7 +1692,7 @@ class Prep():
         optimize_results = []
         if optimize_tasks:
             if use_tqdm():
-                with tqdm(total=len(optimize_tasks), desc="Optimizing Images", ascii=True, dynamic_ncols=False) as pbar:
+                with tqdm(total=len(optimize_tasks), desc="Optimizing Images", ascii=" #", dynamic_ncols=False) as pbar:
                     with get_context("spawn").Pool(processes=min(len(optimize_tasks), task_limit)) as pool:
                         try:
                             for result in pool.imap_unordered(self.optimize_image_task, optimize_tasks):
@@ -3241,7 +3241,7 @@ class Prep():
                                 pool.imap_unordered(self.upload_image_task, upload_tasks),
                                 total=len(upload_tasks),
                                 desc=f"Uploading Images to {img_host}",
-                                ascii=True,
+                                ascii=" #",
                                 dynamic_ncols=False
                             )
                         )


### PR DESCRIPTION
## Summary

Progress bars sometimes showed a stray digit at the end of the fill (e.g. `#####7  | 6/7`). This is tqdm's `ascii=True` behavior: it uses the charset `" 123456789#"`, where digits represent a partially-filled final cell.

This changes all tqdm calls in `src/prep.py` to `ascii=" #"`, restricting the bar to space and `#` so it fills in clean whole steps:

```
Capturing Screenshots:  86%|##########  | 6/7 [00:05<00:00,  1.20it/s]
```